### PR TITLE
Fullscreen por defecto

### DIFF
--- a/andiamo.pde
+++ b/andiamo.pde
@@ -16,11 +16,24 @@ boolean fixed;
 boolean dissapearing;
 boolean grouping;
 
+/**
+ * Sets the sketch in fullscreen
+ * @return true
+ */
+boolean sketchFullScreen() {
+  return true;
+}
+
 void setup() {
   String RENDERER = JAVA2D;
   if (USE_TEXTURES) RENDERER = P2D;
-//  size(displayWidth, displayHeight, RENDERER);
-  size(800, 600, RENDERER);
+
+  if(sketchFullScreen()) {
+    size(displayWidth, displayHeight, RENDERER);
+  } else {
+    size(800, 600, RENDERER);
+  }
+
   frameRate(180);
   smooth(8);
   startup();


### PR DESCRIPTION
Setteo por defecto que el sketch inicie en fullscreen. 

Aparte cambié el nombre de Andiamo.pde por andiamo.pde para que vaya con el standard de processing-java para compilarlo. 
